### PR TITLE
Fix license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,4 @@ A lot of work on quality and improving the embeddings and the search results. I 
 This work is a fork of [searchthearxiv](https://github.com/augustwester/searchthearxiv) project that provides a semantic search for Machine Leaning arxiv papers. I used the code and the idea to create a similar project for LHCb papers.
 
 ## License
-This project is licensed under the GPLv3 License - see the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the GPLv3 License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- update README license hyperlink to match `LICENSE` filename

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6848afd563f08322844c1abb753bd4ca