### PR TITLE
Improve Kaggle updater logging

### DIFF
--- a/model/update_kaggle.py
+++ b/model/update_kaggle.py
@@ -5,25 +5,43 @@ from tqdm import tqdm
 from pinecone import Pinecone
 from paper import Paper
 from helpers import pinecone_embedding_count
+import logging
 
-print("Preparing Kaggle dataset update...")
+# Basic logging setup for some simple debugging information
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+
+logging.info("Preparing Kaggle dataset update...")
 
 ARXIV_FILE_PATH = "arxiv-metadata-oai-snapshot.json"
 EMBEDDING_FILE_PATH = "lhcb-arxiv-embeddings.json"
 INDEX_NAME = os.environ["PINECONE_INDEX_NAME"]
 
+# Always determine how many embeddings are stored in Pinecone so we can
+# compare against the Kaggle dataset.
+num_pinecone = pinecone_embedding_count(INDEX_NAME)
+logging.info(
+    f"Pinecone index '{INDEX_NAME}' currently has {num_pinecone} embeddings"
+)
 
 if os.path.exists(EMBEDDING_FILE_PATH):
-    num_kaggle = sum(1 for _ in open(EMBEDDING_FILE_PATH, "r", encoding="utf-8"))
+    num_kaggle = sum(
+        1 for _ in open(EMBEDDING_FILE_PATH, "r", encoding="utf-8")
+    )
 else:
     num_kaggle = 0
-    print("No existing embeddings file. Starting fresh.")
-    num_pinecone = pinecone_embedding_count(INDEX_NAME)
+    logging.info("No existing embeddings file. Starting fresh.")
+logging.info(f"Local Kaggle embeddings file contains {num_kaggle} entries")
+
 num_new = num_pinecone - num_kaggle
-print(f"{num_new} new embeddings potentially available to update Kaggle dataset.")
+logging.info(
+    f"{num_new} new embeddings potentially available to update Kaggle dataset."
+)
 
 if num_new <= 0:
-    print("No new embeddings to add. Exiting...")
+    logging.info("No new embeddings to add. Exiting...")
     exit(0)
 
 print("Loading LHCb metadata from arXiv snapshot...")
@@ -35,8 +53,11 @@ with open(ARXIV_FILE_PATH, "r", encoding="utf-8") as f:
         if p.has_valid_id and p.is_lhcb_related:
             all_lhcb_papers.append(data_dict)
 
+logging.info(f"Loaded {len(all_lhcb_papers)} LHCb-related papers from snapshot")
+
 # naive approach: take the last `num_new` from this list
 papers_to_update = all_lhcb_papers[-num_new:]
+logging.info(f"Updating {len(papers_to_update)} papers with embeddings")
 
 print("Fetching vectors from Pinecone for these new LHCb papers...")
 pc = Pinecone(api_key=os.environ["PINECONE_API_KEY"])


### PR DESCRIPTION
## Summary
- add logging setup in `update_kaggle.py`
- log Pinecone and Kaggle embedding counts
- log how many papers will be updated

## Testing
- `python -m py_compile model/update_kaggle.py`


------
https://chatgpt.com/codex/tasks/task_e_6848afce72688322a62f0f8f70f91d88